### PR TITLE
Update Jackson, Commons BeanUtils, Resteasy and Classgraph to fix various security vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Security
+- Update Jackson version to **2.15.0** to fix **security vulnerability CVE-2025-52999**
+  Detail: https://cwe.mitre.org/data/definitions/121.html
+- Update commons.beanutils version to **1.11.0** to fix **security vulnerability CVE-2025-48734**
+  Detail: https://cwe.mitre.org/data/definitions/284.html
+- Update resteasy version to **3.15.5.Final** to fix **security vulnerability CVE-2023-0482**
+  Detail: https://cwe.mitre.org/data/definitions/378.html
+- Update classgraph version to **4.8.112** to fix **security vulnerability CVE-2021-47621**
+  Detail: https://cwe.mitre.org/data/definitions/611.html
+
 ## [17.103.0] - 2025-05-28
 ### Added
   - Add dependencies for Micometer Metrics 1.15.0

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
         <blockhound.version>1.0.6.RELEASE</blockhound.version>
         <byte-buddy.version>1.12.22</byte-buddy.version>
         <cdi.api.version>1.2</cdi.api.version>
-        <classgraph.version>4.8.90</classgraph.version>
-        <commons.beanutils.version>1.9.4</commons.beanutils.version>
+        <classgraph.version>4.8.112</classgraph.version>
+        <commons.beanutils.version>1.11.0</commons.beanutils.version>
         <commons-codec.version>1.17.2</commons-codec.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons.cli.version>1.2</commons.cli.version>
@@ -56,7 +56,7 @@
         <hamcrest.regex.version>1.0.1</hamcrest.regex.version>
         <hamcrest.version>2.2</hamcrest.version>
         <hibernate.version>5.4.24.Final</hibernate.version>
-        <jackson.version>2.12.7</jackson.version>
+        <jackson.version>2.15.0</jackson.version>
         <jackson.databind.version>2.12.7.1</jackson.databind.version>
         <jakarta.xml.bind-api.version>2.3.2</jakarta.xml.bind-api.version>
         <java.8.matchers.version>1.1</java.8.matchers.version>


### PR DESCRIPTION
- Update Jackson version to **2.15.0** to fix **security vulnerability CVE-2025-52999**
  Detail: https://cwe.mitre.org/data/definitions/121.html
- Update commons.beanutils version to **1.11.0** to fix **security vulnerability CVE-2025-48734**
  Detail: https://cwe.mitre.org/data/definitions/284.html
- Update resteasy version to **3.15.5.Final** to fix **security vulnerability CVE-2023-0482**
  Detail: https://cwe.mitre.org/data/definitions/378.html
- Update classgraph version to **4.8.112** to fix **security vulnerability CVE-2021-47621**
  Detail: https://cwe.mitre.org/data/definitions/611.html
